### PR TITLE
i18n MX states fix, changed accented characters to HTML Code

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -504,6 +504,8 @@ function wc_update_attribute( $id, $args ) {
  * @return bool
  */
 function wc_delete_attribute( $id ) {
+	global $wpdb;
+
 	$deleted = $wpdb->delete(
 		$wpdb->prefix . 'woocommerce_attribute_taxonomies',
 		array( 'attribute_id' => $id ),

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -512,7 +512,7 @@ function wc_delete_attribute( $id ) {
 		array( '%d' )
 	);
 
-	if ( false === $deleted ) {
+	if ( in_array( $deleted, array( 0, false ), true ) ) {
 		return false;
 	}
 

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -347,3 +347,34 @@ function wc_is_attribute_in_product_name( $attribute, $name ) {
 function wc_array_filter_default_attributes( $attribute ) {
 	return ( ! empty( $attribute ) || '0' === $attribute );
 }
+
+/**
+ * Get attribute data by ID.
+ *
+ * @since  3.2.0
+ * @param  int $id Attribute ID.
+ * @return stdClass|null
+ */
+function wc_get_attribute( $id ) {
+	global $wpdb;
+
+	$data = $wpdb->get_row( $wpdb->prepare( "
+		SELECT *
+		FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+		WHERE attribute_id = %d
+	 ", $id ) );
+
+	if ( is_wp_error( $data ) || is_null( $data ) ) {
+		return null;
+	}
+
+	$attribute               = new stdClass();
+	$attribute->id           = (int) $data->attribute_id;
+	$attribute->name         = $data->attribute_label;
+	$attribute->slug         = wc_attribute_taxonomy_name( $data->attribute_name );
+	$attribute->type         = $data->attribute_type;
+	$attribute->order_by     = $data->attribute_orderby;
+	$attribute->has_archives = (bool) $data->attribute_public;
+
+	return $attribute;
+}

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -445,7 +445,7 @@ function wc_create_attribute( $args ) {
 	if ( 0 === $id ) {
 		$results = $wpdb->insert(
 			$wpdb->prefix . 'woocommerce_attribute_taxonomies',
-			$args,
+			$data,
 			$format
 		);
 
@@ -457,7 +457,7 @@ function wc_create_attribute( $args ) {
 	} else {
 		$results = $wpdb->update(
 			$wpdb->prefix . 'woocommerce_attribute_taxonomies',
-			$args,
+			$data,
 			array( 'attribute_id' => $id ),
 			$format,
 			array( '%d' )
@@ -467,6 +467,9 @@ function wc_create_attribute( $args ) {
 			return new WP_Error( 'cannot_update_attribute', __( 'Could not update the attribute.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 	}
+
+	// Clear transients.
+	delete_transient( 'wc_attribute_taxonomies' );
 
 	return $id;
 }
@@ -510,6 +513,9 @@ function wc_delete_attribute( $id ) {
 	if ( false === $deleted ) {
 		return false;
 	}
+
+	// Clear transients.
+	delete_transient( 'wc_attribute_taxonomies' );
 
 	return true;
 }

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -492,3 +492,24 @@ function wc_update_attribute( $id, $args ) {
 
 	return wc_create_attribute( $args );
 }
+
+/**
+ * Delete attribute by ID.
+ *
+ * @since  3.2.0
+ * @param  int $id Attribute ID.
+ * @return bool
+ */
+function wc_delete_attribute( $id ) {
+	$deleted = $wpdb->delete(
+		$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+		array( 'attribute_id' => $id ),
+		array( '%d' )
+	);
+
+	if ( false === $deleted ) {
+		return false;
+	}
+
+	return true;
+}

--- a/tests/unit-tests/attributes/functions.php
+++ b/tests/unit-tests/attributes/functions.php
@@ -1,0 +1,116 @@
+<<?php
+
+/**
+ * Class Functions.
+ * @package WooCommerce\Tests\Attributes
+ * @since 3.2.0
+ */
+class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests wc_get_attribute().
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_wc_get_attribute() {
+		$args = array(
+			'name'         => 'Brand',
+			'type'         => 'select',
+			'order_by'     => 'name',
+			'has_archives' => true,
+		);
+
+		$id = wc_create_attribute( $args );
+
+		$attribute = (array) wc_get_attribute( $id );
+		$expected  = array(
+			'id'           => $id,
+			'name'         => 'Brand',
+			'slug'         => 'pa_brand',
+			'type'         => 'select',
+			'order_by'     => 'name',
+			'has_archives' => true,
+		);
+
+		wc_delete_attribute( $id );
+
+		$this->assertEquals( $expected, $attribute );
+	}
+
+	/**
+	 * Tests wc_create_attribute().
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_wc_create_attribute() {
+		// Test success.
+		$id = wc_create_attribute( array( 'name' => 'Brand' ) );
+		$this->assertInternalType( 'int', $id );
+
+		// Test failures.
+		$err = wc_create_attribute( array() );
+		$this->assertEquals( 'missing_attribute_name', $err->get_error_code() );
+
+		$err = wc_create_attribute( array( 'name' => 'This is a big name for a product attribute!' ) );
+		$this->assertEquals( 'invalid_product_attribute_slug_too_long', $err->get_error_code() );
+
+		$err = wc_create_attribute( array( 'name' => 'Cat' ) );
+		$this->assertEquals( 'invalid_product_attribute_slug_reserved_name', $err->get_error_code() );
+
+		register_taxonomy( 'pa_brand', array( 'product' ), array( 'labels' => array( 'name' => 'Brand' ) ) );
+		$err = wc_create_attribute( array( 'name' => 'Brand' ) );
+		$this->assertEquals( 'invalid_product_attribute_slug_already_exists', $err->get_error_code() );
+		unregister_taxonomy( 'pa_brand' );
+
+		wc_delete_attribute( $id );
+	}
+
+	/**
+	 * Tests wc_update_attribute().
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_wc_update_attribute() {
+		$args = array(
+			'name'         => 'Brand',
+			'type'         => 'select',
+			'order_by'     => 'name',
+			'has_archives' => true,
+		);
+
+		$id = wc_create_attribute( $args );
+
+		$updated = array(
+			'id'           => $id,
+			'name'         => 'Brand',
+			'slug'         => 'pa_brand',
+			'type'         => 'text',
+			'order_by'     => 'menu_order',
+			'has_archives' => true,
+		);
+
+		wc_update_attribute( $id, $updated );
+
+		$attribute = (array) wc_get_attribute( $id );
+
+		wc_delete_attribute( $id );
+
+		$this->assertEquals( $updated, $attribute );
+	}
+
+	/**
+	 * Tests wc_delete_attribute().
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_wc_delete_attribute() {
+		// Success.
+		$id     = wc_create_attribute( array( 'name' => 'Brand' ) );
+		$result = wc_delete_attribute( $id );
+		$this->assertTrue( $result );
+
+		// Failure.
+		$result = wc_delete_attribute( 9999999 );
+		$this->assertFalse( $result );
+	}
+}


### PR DESCRIPTION
Accented characters are now using the correct HTML code `acute`, users were experiencing problems in order acceptance when using a state with a special character.